### PR TITLE
Improved parsing of parallel states

### DIFF
--- a/src/scxml_interpreter/smach_builder.py
+++ b/src/scxml_interpreter/smach_builder.py
@@ -96,7 +96,7 @@ class SmachBuilder(object):
 
     def create_parallel_state(self, state_interface):
         return smach.Concurrence(state_interface.get_outcomes(),
-                                 default_outcome="default",
+                                 default_outcome="failed",
                                  outcome_map=state_interface.outcome_map,
                                  )
 


### PR DESCRIPTION
Fixed the creation of preempted, aborted and failed transitions in parallel states.
Requires pull request 65 of executive_smach repository.
https://github.com/ros/executive_smach/pull/65