### PR TITLE
Changed parsing of cond in parallel states for compatibility with smach

### DIFF
--- a/src/scxml_interpreter/scxml_parser.py
+++ b/src/scxml_interpreter/scxml_parser.py
@@ -13,18 +13,43 @@ def convert_to_concurence_map(cond):
     # split mapping
     cond_ = cond.strip()
     map_list = []
-    if(cond_.find(' AND ') == -1):  # There is no "and" condition
-        if(cond_.find(' OR ') == -1):  # There is no "or" condition
+    if(cond_.find(' AND ') == -1):                          # There is no "and" condition
+        if(cond_.find(' OR ') == -1):                       # There is no "or" condition
             list_ = cond_.split('.')
             map_list.append({list_[0]: list_[1]})
-        else:
+            
+        else:                                               # There is only "or" condition
+            
+            # State1.succeeded OR State2.succeeded
+            # succeeded: [{State1: succeeded} , {State2: succeeded }]
+            
             for cond_or in cond_.split(' OR '):
                 list_ = cond_or.split('.')
                 map_list.append({list_[0]: list_[1]})
     else:
-        for cond_and in cond_.split(' AND '):
-            list_and = cond_and.split('.')
-            map_list.append({list_and[0]: list_and[1]})
+        
+        if(cond_.find(' OR ') == -1):                       # There is no only "and" condition
+            
+            # State1.succeeded AND State2.succeeded
+            # succeeded: [{State1: succeeded, State2: succeeded }]
+            
+            cond_and_dict = {}
+            for cond_and_parcel in cond_.split(' AND '):
+                list_and = cond_and_parcel.split('.')
+                cond_and_dict[list_and[0]] = list_and[1]
+                
+            map_list.append(cond_and_dict)
+            
+        else:                                               # There is no both "or" and "and" conditions
+            for cond_or in cond_.split(' OR '):
+                
+                cond_and_dict = {}
+                for cond_and_parcel in cond_or.split(' AND '):
+                    list_and = cond_and_parcel.split('.')
+                    cond_and_dict[list_and[0]] = list_and[1]
+                
+                map_list.append(cond_and_dict)
+
     return map_list
 
 

--- a/src/scxml_interpreter/scxml_parser.py
+++ b/src/scxml_interpreter/scxml_parser.py
@@ -12,43 +12,35 @@ def convert_to_concurence_map(cond):
     # split mapping
     cond_ = cond.strip()
     map_list = []
-    if(cond_.find(' AND ') == -1):                          # There are no "and" conditions
-        if(cond_.find(' OR ') == -1):                       # There are no "or" conditions
+    if(cond_.find(' AND ') == -1):                          # there are no "and" conditions
+        if(cond_.find(' OR ') == -1):                       # there are no "or" conditions
             list_ = cond_.split('.')
             map_list.append({list_[0]: list_[1]})
-            
-        else:                                               # There are only "or" conditions
+        else:                                               # there are only "or" conditions
             
             # State1.succeeded OR State2.succeeded
             # succeeded: [{State1: succeeded} , {State2: succeeded }]
-            
             for cond_or in cond_.split(' OR '):
                 list_ = cond_or.split('.')
                 map_list.append({list_[0]: list_[1]})
     else:
-        
-        if(cond_.find(' OR ') == -1):                       # There are only "and" conditions
+        if(cond_.find(' OR ') == -1):                       # there are only "and" conditions
             
             # State1.succeeded AND State2.succeeded
             # succeeded: [{State1: succeeded, State2: succeeded }]
-            
             cond_and_dict = {}
             for cond_and_parcel in cond_.split(' AND '):
                 list_and = cond_and_parcel.split('.')
-                cond_and_dict[list_and[0]] = list_and[1]
-                
+                cond_and_dict[list_and[0]] = list_and[1]   
             map_list.append(cond_and_dict)
             
-        else:                                               # There are both "or" and "and" conditions
+        else:                                               # there are both "or" and "and" conditions
             for cond_or in cond_.split(' OR '):
-                
                 cond_and_dict = {}
                 for cond_and_parcel in cond_or.split(' AND '):
                     list_and = cond_and_parcel.split('.')
                     cond_and_dict[list_and[0]] = list_and[1]
-                
                 map_list.append(cond_and_dict)
-
     return map_list
 
 class Converter(object):

--- a/src/scxml_interpreter/scxml_parser.py
+++ b/src/scxml_interpreter/scxml_parser.py
@@ -8,17 +8,16 @@ import os
 from scxml_interpreter.interfaces import SimpleStateInterface, CompoundStateInterface, \
                                         SCXMLInterface, ParallelStateInterface
 
-
 def convert_to_concurence_map(cond):
     # split mapping
     cond_ = cond.strip()
     map_list = []
-    if(cond_.find(' AND ') == -1):                          # There is no "and" condition
-        if(cond_.find(' OR ') == -1):                       # There is no "or" condition
+    if(cond_.find(' AND ') == -1):                          # There are no "and" conditions
+        if(cond_.find(' OR ') == -1):                       # There are no "or" conditions
             list_ = cond_.split('.')
             map_list.append({list_[0]: list_[1]})
             
-        else:                                               # There is only "or" condition
+        else:                                               # There are only "or" conditions
             
             # State1.succeeded OR State2.succeeded
             # succeeded: [{State1: succeeded} , {State2: succeeded }]
@@ -28,7 +27,7 @@ def convert_to_concurence_map(cond):
                 map_list.append({list_[0]: list_[1]})
     else:
         
-        if(cond_.find(' OR ') == -1):                       # There is no only "and" condition
+        if(cond_.find(' OR ') == -1):                       # There are only "and" conditions
             
             # State1.succeeded AND State2.succeeded
             # succeeded: [{State1: succeeded, State2: succeeded }]
@@ -40,7 +39,7 @@ def convert_to_concurence_map(cond):
                 
             map_list.append(cond_and_dict)
             
-        else:                                               # There is no both "or" and "and" conditions
+        else:                                               # There are both "or" and "and" conditions
             for cond_or in cond_.split(' OR '):
                 
                 cond_and_dict = {}
@@ -51,7 +50,6 @@ def convert_to_concurence_map(cond):
                 map_list.append(cond_and_dict)
 
     return map_list
-
 
 class Converter(object):
 


### PR DESCRIPTION

State1.succeeded OR State2.succeeded --> [{State1: succeeded} , {State2: succeeded }]; State1.succeeded AND State2.succeeded --> succeeded: [{State1: succeeded, State2: succeeded }]